### PR TITLE
version 3 change 'volumes_from' to 'volumes'

### DIFF
--- a/{{cookiecutter.project_name}}/docker-compose-nginx.yml
+++ b/{{cookiecutter.project_name}}/docker-compose-nginx.yml
@@ -12,7 +12,6 @@ services:
             - "./docker/files/nginx.conf:/etc/nginx/nginx.conf"
             - "./docker/files/shared:/shared:rw"
             - "./docker/files/var/log:/var/log:rw"
-        volumes_from:
             - web
     web:
         command: uwsgi


### PR DESCRIPTION
[Compose file version 3 snippet](https://docs.docker.com/compose/compose-file/)
Note: The top-level volumes key defines a named volume and references it from each service’s volumes list. This replaces volumes_from in earlier versions of the Compose file format. See Use volumes and Volume Plugins for general information on volumes.